### PR TITLE
Ensure selected video is saved correctly

### DIFF
--- a/includes/video-functions.php
+++ b/includes/video-functions.php
@@ -33,8 +33,13 @@ function avp_video_meta_callback($post) {
 
 function avp_video_url_callback($post) {
     wp_nonce_field('avp_video_url_nonce_action', 'avp_video_url_nonce');
-    $url = get_post_meta($post->ID, '_avp_video_url', true);
+    $url      = get_post_meta($post->ID, '_avp_video_url', true);
+    $video_id = get_post_meta($post->ID, '_avp_video_id', true);
+    if (!$url && $video_id) {
+        $url = wp_get_attachment_url($video_id);
+    }
     ?>
+    <input type="hidden" id="avp_video_id" name="avp_video_id" value="<?php echo esc_attr($video_id); ?>">
     <input type="text" id="avp_video_url" name="avp_video_url" value="<?php echo esc_url($url); ?>" style="width:100%;" readonly>
     <p>
         <button type="button" class="button" id="avp_upload_video_btn">آپلود یا انتخاب ویدیو</button>
@@ -55,12 +60,15 @@ function avp_video_url_callback($post) {
             mediaUploader.on('select', function(){
                 var a = mediaUploader.state().get('selection').first().toJSON();
                 $('#avp_video_url').val(a.url);
+                $('#avp_video_id').val(a.id);
                 $('#avp_remove_video_btn').show();
             });
             mediaUploader.open();
         });
         $('#avp_remove_video_btn').on('click', function(){
-            $('#avp_video_url').val(''); $(this).hide();
+            $('#avp_video_url').val('');
+            $('#avp_video_id').val('');
+            $(this).hide();
         });
     });
     </script>
@@ -81,5 +89,6 @@ add_action('save_post', function ($post_id) {
 
     if (isset($_POST['avp_video_url_nonce']) && wp_verify_nonce($_POST['avp_video_url_nonce'], 'avp_video_url_nonce_action')) {
         if (isset($_POST['avp_video_url'])) update_post_meta($post_id, '_avp_video_url', esc_url_raw($_POST['avp_video_url']));
+        update_post_meta($post_id, '_avp_video_id', intval($_POST['avp_video_id'] ?? 0));
     }
 });


### PR DESCRIPTION
## Summary
- Save both video URL and attachment ID when choosing a video
- Preserve selected video via stored ID even if URL is missing

## Testing
- `php -l includes/video-functions.php`


------
https://chatgpt.com/codex/tasks/task_b_68ba89ec5ca08328bb1eba1c1f51d6a3