### PR TITLE
Overhaul video upload handling

### DIFF
--- a/assets/js/admin-video.js
+++ b/assets/js/admin-video.js
@@ -1,11 +1,9 @@
 // اجرا در صفحات ادمین
 jQuery(function ($) {
-  // اگر متاباکس ما وجود ندارد، کاری نکن
-  if (!$('#avp_video_url').length) return;
+  if (!$('#avp_video_id').length) return;
 
   var frame;
 
-  // کلیک روی دکمه انتخاب
   $(document).on('click', '#avp_upload_video_btn', function (e) {
     e.preventDefault();
 
@@ -20,21 +18,17 @@ jQuery(function ($) {
 
     frame.on('select', function () {
       var att = frame.state().get('selection').first().toJSON();
-      $('#avp_video_url').val(att.url);
+      $('#avp_video_id').val(att.id);
+      $('#avp_video_preview').html('<video src="' + att.url + '" controls style="max-width:100%;height:auto;"></video>');
       $('#avp_remove_video_btn').show();
-      // برای اطمینان، یک تریگر تغییر هم بزن
-      $('#avp_video_url').trigger('change');
-      console.log('AVP: video selected ->', att.url);
     });
 
     frame.open();
   });
 
-  // حذف
   $(document).on('click', '#avp_remove_video_btn', function () {
-    $('#avp_video_url').val('');
+    $('#avp_video_id').val('');
+    $('#avp_video_preview').html('');
     $(this).hide();
   });
-
-  console.log('AVP admin-video.js ready');
 });

--- a/includes/quiz-functions.php
+++ b/includes/quiz-functions.php
@@ -55,7 +55,8 @@ add_shortcode('avp_video_quiz', function () {
     if (!is_singular('avp_video')) return '';
 
     global $post;
-    $video = get_post_meta($post->ID, '_avp_video_url', true);
+    $video_id = (int) get_post_meta($post->ID, '_avp_video_id', true);
+    $video = $video_id ? wp_get_attachment_url($video_id) : '';
     $q     = get_post_meta($post->ID, '_avp_quiz_question', true);
     $opts  = [];
     for ($i=1; $i<=4; $i++) $opts[$i] = get_post_meta($post->ID, "_avp_option_$i", true);

--- a/includes/video-functions.php
+++ b/includes/video-functions.php
@@ -33,37 +33,17 @@ function avp_video_meta_callback($post) {
 
 function avp_video_url_callback($post) {
     wp_nonce_field('avp_video_url_nonce_action', 'avp_video_url_nonce');
-    $url = get_post_meta($post->ID, '_avp_video_url', true);
+    $video_id = (int) get_post_meta($post->ID, '_avp_video_id', true);
+    $url = $video_id ? wp_get_attachment_url($video_id) : '';
     ?>
-    <input type="text" id="avp_video_url" name="avp_video_url" value="<?php echo esc_url($url); ?>" style="width:100%;" readonly>
+    <input type="hidden" id="avp_video_id" name="avp_video_id" value="<?php echo esc_attr($video_id); ?>">
+    <div id="avp_video_preview" style="margin-bottom:10px;">
+        <?php if ($url) echo wp_video_shortcode(['src' => esc_url($url)]); ?>
+    </div>
     <p>
         <button type="button" class="button" id="avp_upload_video_btn">آپلود یا انتخاب ویدیو</button>
-        <button type="button" class="button" id="avp_remove_video_btn" style="display:<?php echo $url ? 'inline-block':'none';?>">حذف</button>
+        <button type="button" class="button" id="avp_remove_video_btn" style="display:<?php echo $url ? 'inline-block' : 'none'; ?>;">حذف</button>
     </p>
-    <script>
-    jQuery(function($){
-        var mediaUploader;
-        $('#avp_upload_video_btn').on('click', function(e){
-            e.preventDefault();
-            if (mediaUploader) { mediaUploader.open(); return; }
-            mediaUploader = wp.media({
-                title: 'انتخاب یا آپلود ویدیو',
-                button: { text: 'استفاده از این ویدیو' },
-                library: { type: 'video' },
-                multiple: false
-            });
-            mediaUploader.on('select', function(){
-                var a = mediaUploader.state().get('selection').first().toJSON();
-                $('#avp_video_url').val(a.url);
-                $('#avp_remove_video_btn').show();
-            });
-            mediaUploader.open();
-        });
-        $('#avp_remove_video_btn').on('click', function(){
-            $('#avp_video_url').val(''); $(this).hide();
-        });
-    });
-    </script>
     <?php
 }
 
@@ -80,6 +60,12 @@ add_action('save_post', function ($post_id) {
     }
 
     if (isset($_POST['avp_video_url_nonce']) && wp_verify_nonce($_POST['avp_video_url_nonce'], 'avp_video_url_nonce_action')) {
-        if (isset($_POST['avp_video_url'])) update_post_meta($post_id, '_avp_video_url', esc_url_raw($_POST['avp_video_url']));
+        $vid = intval($_POST['avp_video_id'] ?? 0);
+        if ($vid) {
+            update_post_meta($post_id, '_avp_video_id', $vid);
+        } else {
+            delete_post_meta($post_id, '_avp_video_id');
+        }
+        delete_post_meta($post_id, '_avp_video_url');
     }
 });


### PR DESCRIPTION
## Summary
- Replace video URL field with attachment ID and preview element
- Update admin script to set attachment ID and show selected video
- Retrieve video URL from stored attachment ID on front-end

## Testing
- `php -l includes/video-functions.php`
- `php -l includes/quiz-functions.php`
- `node --check assets/js/admin-video.js`


------
https://chatgpt.com/codex/tasks/task_b_68ba89ec5ca08328bb1eba1c1f51d6a3